### PR TITLE
FIX: Issue where no ringtone is selected

### DIFF
--- a/ringtonepicker/src/main/java/com/kevalpatel/ringtonepicker/RingtonePickerDialog.java
+++ b/ringtonepicker/src/main/java/com/kevalpatel/ringtonepicker/RingtonePickerDialog.java
@@ -311,7 +311,11 @@ public final class RingtonePickerDialog extends DialogFragment implements Ringto
                 .setPositiveButton(mPositiveButtonTitle, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        mListener.OnRingtoneSelected(mCurrentRingTone.first, mCurrentRingTone.second);
+                        if(mCurrentRingTone.first != null){
+                            mListener.OnRingtoneSelected(mCurrentRingTone.first, mCurrentRingTone.second);
+                        }else{
+                            dialog.dismiss();
+                        }
                     }
                 })
                 .setNegativeButton(mNegativeButtonTitle, null)


### PR DESCRIPTION
FIX crash `java.lang.NullPointerException` on `mCurrentRingTone.first` when no ringtone is selected